### PR TITLE
feat(layout): introduce countdown layout

### DIFF
--- a/components/layout_countdown.js
+++ b/components/layout_countdown.js
@@ -1,0 +1,24 @@
+import styles from "./layout.module.css";
+import Article from "./article.js";
+import Card from "./card.js";
+import Details from "./details.js";
+import Countdown from "./countdown";
+
+export default function Layout({ children, title, author, date }) {
+  const { day, month, year } = date;
+
+  return (
+    <div className={styles.layout}>
+      <Article>
+        <Countdown />
+        <div className={styles.sep}></div>
+        <Card type="regular">{title}</Card>
+        <Details author={author} day={day} month={month} year={year} />
+        <div className={styles.sep}></div>
+        <div className={styles.content}>
+          {children}
+        </div>
+      </Article>
+    </div>
+  );
+}

--- a/pages/countdown.js
+++ b/pages/countdown.js
@@ -1,5 +1,4 @@
-import Countdown from "../components/countdown";
-import Layout from "../components/layout"
+import Layout from "../components/layout_countdown"
 
 export default function Home() {
 
@@ -9,7 +8,7 @@ export default function Home() {
         author="Centauri Hacks"
         date={{ day: 69, month: 69, year: 6969 }}
       >
-        <Countdown />
+        <p>Here is a plcae for potential future content regarding the preparation for the Hackathon.</p>
       </Layout>
     );
 }


### PR DESCRIPTION
As suggested to @BlueFalconHD in a private conversation:

This PR introduces a new layout that will always display the countdown on top of the given pages content. This is done firstly for the countdown subpage itself where the countdown should be the first thing the user sees – it might also be a good idea to make the styling pop out a little more like it is done with the title card for example.

I've chosen to create a new layout for this in order to allow for future reuse and expandability of this without disturbing any of the other child elements that or other pages might have.